### PR TITLE
ui: fix max width of main container

### DIFF
--- a/public/basic.css
+++ b/public/basic.css
@@ -23,7 +23,7 @@ main {
     border-radius: 8px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     width: 80%;
-    max-width: 640px;
+    max-width: 800;
     min-width: 280px;
     justify-self: center;
 


### PR DESCRIPTION
Closes #4 

Enlarged main container's max-width to 800px. By this change, in case where the main container is properly large ( > 800px), three link buttons ( > 200px) are arranged in one row of css-grid ( with width of 800px * 0.8 = 640px).