### PR TITLE
fix: enlarge main container's max-width to arrange link buttons properly

### DIFF
--- a/public/basic.css
+++ b/public/basic.css
@@ -23,7 +23,7 @@ main {
     border-radius: 8px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     width: 80%;
-    max-width: 800;
+    max-width: 800px;
     min-width: 280px;
     justify-self: center;
 


### PR DESCRIPTION
Enlarged main container's max-width to 800px. By this change, in case where the main container is properly large ( > 800px), three link buttons ( > 200px) are arranged in one row of css-grid ( with width of 800px * 0.8 = 640px).

Closes #4 